### PR TITLE
refactor: change how email confirmation pipeline works

### DIFF
--- a/public/templates/confirmation.html
+++ b/public/templates/confirmation.html
@@ -6,7 +6,7 @@
 <p>Follow this link to confirm email address:</p>
 <p>
   <a
-    href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=email&next={{ .RedirectTo }}"
+    href="{{ .SiteURL }}/confirm-email?token_hash={{ .TokenHash }}&type=email&next={{ .RedirectTo }}"
   >Confirm your email</a>
 </p>
 

--- a/public/templates/confirmation.html
+++ b/public/templates/confirmation.html
@@ -6,7 +6,7 @@
 <p>Follow this link to confirm email address:</p>
 <p>
   <a
-    href="{{ .SiteURL }}/confirm-email?token_hash={{ .TokenHash }}&type=email&next={{ .RedirectTo }}"
+    href="{{ .Data.siteUrl }}/confirm-email?token_hash={{ .TokenHash }}&type=email&next={{ .RedirectTo }}"
   >Confirm your email</a>
 </p>
 

--- a/src/app/(api)/auth/confirm/route.ts
+++ b/src/app/(api)/auth/confirm/route.ts
@@ -2,13 +2,15 @@ import type { EmailOtpType } from "@supabase/supabase-js";
 import { NextResponse } from "next/server";
 
 import { completeSignUp, verifyOtp } from "@/lib/auth";
+import { env } from "@/env";
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
 
+  const origin = env.NEXT_PUBLIC_SITE_URL;
   const tokenHash = searchParams.get("token_hash");
   const type = searchParams.get("type") as EmailOtpType | null;
-  const next = searchParams.get("next") ?? "/";
+  const next = searchParams.get("next") ?? origin;
 
   // Verify OTP and log in
   if (tokenHash && type) {
@@ -16,7 +18,7 @@ export async function GET(request: Request) {
     if (verified.isErr()) {
       const errorMessage = "Error exchanging code for session: " + verified.error.message;
       console.error(errorMessage);
-      return NextResponse.redirect(`/error?error=${encodeURI(errorMessage)}`);
+      return NextResponse.redirect(`${origin}/error?error=Could not verify. Maybe the link is expired?`);
     }
   }
 
@@ -26,14 +28,18 @@ export async function GET(request: Request) {
     if (completed.isErr()) {
       const errorMessage = "Error completing sign up: " + completed.error.message;
       console.error(errorMessage);
-      return NextResponse.redirect(`/error?error=${encodeURI(errorMessage)}`);
+      return NextResponse.redirect(`${origin}/error?error=Could not complete sign up. Maybe duplicate information?`);
     }
   }
 
   if (next) {
+    // If next is a relative path, prepend the origin
+    if (!next.startsWith("http")) {
+      return NextResponse.redirect(`${origin}${next}`);
+    }
     return NextResponse.redirect(next);
   }
 
   // URL to redirect to after sign up process completes
-  return NextResponse.redirect(`/my`);
+  return NextResponse.redirect(`${origin}/my`);
 }

--- a/src/app/(auth-pages)/confirm-email/confirm-button.tsx
+++ b/src/app/(auth-pages)/confirm-email/confirm-button.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+
+export function ConfirmButton() {
+  const searchParams = useSearchParams();
+  const pathname = "/auth/confirm?" + new URLSearchParams(searchParams.toString());
+  return (
+    <Button className="w-fit mt-6" variant="default">
+      <Link href={pathname} prefetch={false}>
+        Confirm!
+      </Link>
+    </Button>
+  );
+}

--- a/src/app/(auth-pages)/confirm-email/confirm-button.tsx
+++ b/src/app/(auth-pages)/confirm-email/confirm-button.tsx
@@ -1,18 +1,22 @@
 "use client";
 
-import Link from "next/link";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
 
 export function ConfirmButton() {
   const searchParams = useSearchParams();
   const pathname = "/auth/confirm?" + new URLSearchParams(searchParams.toString());
+  const router = useRouter();
   return (
-    <Button className="w-fit mt-6" variant="default">
-      <Link href={pathname} prefetch={false}>
-        Confirm!
-      </Link>
+    <Button
+      className="w-fit mt-6"
+      variant="default"
+      onClick={() => {
+        router.push(pathname);
+      }}
+    >
+      Confirm!
     </Button>
   );
 }

--- a/src/app/(auth-pages)/confirm-email/page.tsx
+++ b/src/app/(auth-pages)/confirm-email/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from "next";
+import { Suspense } from "react";
+
+import { ConfirmButton } from "./confirm-button";
+import { TypographyH1 } from "@/components/typography/headings";
+import { TypographyLink, TypographyParagraph } from "@/components/typography/paragraph";
+
+export const metadata: Metadata = {
+  title: "Confirm Your Account",
+  description: "Click the button below to confirm your account.",
+  openGraph: {
+    title: "Confirm Your Account",
+    description: "Click the button below to confirm your account.",
+  },
+};
+
+export default function Page() {
+  return (
+    <div className="flex flex-col max-w-prose">
+      <TypographyH1>Confirm Your Account</TypographyH1>
+      <TypographyParagraph>
+        Click the button below to confirm your account. If you have already confirmed your account, you can{" "}
+        <TypographyLink href="/sign-in">sign in</TypographyLink>.
+      </TypographyParagraph>
+      <Suspense>
+        <ConfirmButton />
+      </Suspense>
+    </div>
+  );
+}

--- a/src/app/(auth-pages)/confirm-email/page.tsx
+++ b/src/app/(auth-pages)/confirm-email/page.tsx
@@ -19,7 +19,7 @@ export default function Page() {
     <div className="flex flex-col max-w-prose">
       <TypographyH1>Confirm Your Account</TypographyH1>
       <TypographyParagraph>
-        Click the button below to confirm your account. If you have already confirmed your account, you can{" "}
+        Click the button below to confirm your account. If you have already confirmed your account, you can just{" "}
         <TypographyLink href="/sign-in">sign in</TypographyLink>.
       </TypographyParagraph>
       <Suspense>

--- a/src/app/(auth-pages)/confirmation-sent/page.tsx
+++ b/src/app/(auth-pages)/confirmation-sent/page.tsx
@@ -23,7 +23,7 @@ export default async function Page({ searchParams }: { searchParams: Promise<{ e
       <TypographyH1>Confirmation Email Sent</TypographyH1>
       {email ? (
         <TypographyParagraph>
-          To confirm your account, you need to click on the link sent to your email at {email}, and follow the
+          To confirm your account, you need to click on the link sent to your email at <b>{email}</b>, and follow the
           instructions. If you have already confirmed your account, you can directly sign in.
         </TypographyParagraph>
       ) : (

--- a/src/app/(auth-pages)/confirmation-sent/page.tsx
+++ b/src/app/(auth-pages)/confirmation-sent/page.tsx
@@ -1,0 +1,50 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { ResendButton } from "./resend-button";
+import { TypographyParagraph, TypographySmall } from "@/components/typography/paragraph";
+import { TypographyH1 } from "@/components/typography/headings";
+import { Button } from "@/components/ui/button";
+
+export const metadata: Metadata = {
+  title: "Confirmation Email Sent",
+  description: "Please check your email to confirm your account.",
+  openGraph: {
+    title: "Confirmation Email Sent",
+    description: "Please check your email to confirm your account.",
+  },
+};
+
+export default async function Page({ searchParams }: { searchParams: Promise<{ email?: string }> }) {
+  const { email } = await searchParams;
+
+  return (
+    <div className="flex flex-col max-w-prose">
+      <TypographyH1>Confirmation Email Sent</TypographyH1>
+      {email ? (
+        <TypographyParagraph>
+          To confirm your account, you need to click on the link sent to your email at {email}, and follow the
+          instructions. If you have already confirmed your account, you can directly sign in.
+        </TypographyParagraph>
+      ) : (
+        <TypographyParagraph>
+          To confirm your account, you need to click on the link sent to your email. If you have already confirmed your
+          account, you can directly sign in.
+        </TypographyParagraph>
+      )}
+      <TypographyParagraph>
+        If you don&apos;t see the email, please check your spam folder, or click the button below to resend the
+        confirmation email.
+      </TypographyParagraph>
+      <TypographySmall className="mt-6">
+        (ps. If you are using Microsoft email (so @kcl.ac.uk), it might take a few minutes for the email to arrive.)
+      </TypographySmall>
+      <div className="flex flex-row mt-8 gap-2">
+        <Button className="w-fit" variant="default">
+          <Link href="/sign-in">Continue to Sign In</Link>
+        </Button>
+        {email ? <ResendButton email={email} /> : null}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(auth-pages)/confirmation-sent/resend-button.tsx
+++ b/src/app/(auth-pages)/confirmation-sent/resend-button.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/hooks/use-toast";
+import { resendSignUpEmailConfirmationAction } from "@/server/auth/sign-up";
+import { actionResultMatch } from "@/types/error-typing";
+
+export function ResendButton({ email }: { email: string }) {
+  const [loading, setLoading] = useState(false);
+  const { toast } = useToast();
+
+  return (
+    <Button
+      className="w-fit"
+      variant="outline"
+      disabled={loading}
+      onClick={async () => {
+        setLoading(true);
+        const result = await resendSignUpEmailConfirmationAction(email);
+        setLoading(false);
+        actionResultMatch(
+          result,
+          () =>
+            toast({
+              title: "Confirmation Email Resent",
+              description: "Please check your email for the new confirmation link.",
+            }),
+          (error) =>
+            toast({
+              title: "Resend Confirmation Email Failed",
+              description: "Please try again. " + error.message,
+              variant: "destructive",
+            }),
+        );
+      }}
+    >
+      Resend Confirmation Email
+    </Button>
+  );
+}

--- a/src/app/(auth-pages)/sign-in/form.tsx
+++ b/src/app/(auth-pages)/sign-in/form.tsx
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
@@ -15,7 +15,10 @@ import { actionResultMatch } from "@/types/error-typing";
 import { TypographyLink } from "@/components/typography/paragraph";
 import { signInAction } from "@/server/auth/sign-in";
 
-export function SignInForm({ redirect }: { redirect?: string }) {
+export function SignInForm() {
+  const searchParams = useSearchParams();
+  const redirect = searchParams.get("redirect");
+
   const { toast } = useToast();
   const [pending, setPending] = useState(false);
   const router = useRouter();

--- a/src/app/(auth-pages)/sign-in/page.tsx
+++ b/src/app/(auth-pages)/sign-in/page.tsx
@@ -1,5 +1,6 @@
 import { type Metadata } from "next";
 
+import { Suspense } from "react";
 import { SignInForm } from "./form";
 import { TypographyH1 } from "@/components/typography/headings";
 import { TypographyLink, TypographyParagraph } from "@/components/typography/paragraph";
@@ -13,8 +14,7 @@ export const metadata: Metadata = {
   },
 };
 
-export default async function Login({ searchParams }: { searchParams: Promise<{ redirect?: string }> }) {
-  const { redirect } = await searchParams;
+export default function Login() {
   return (
     <div className="flex flex-col max-w-prose">
       <TypographyH1>Sign In</TypographyH1>
@@ -25,7 +25,9 @@ export default async function Login({ searchParams }: { searchParams: Promise<{ 
         </TypographyLink>
       </TypographyParagraph>
       <div className="flex flex-col gap-2 mt-4">
-        <SignInForm redirect={redirect} />
+        <Suspense>
+          <SignInForm />
+        </Suspense>
       </div>
     </div>
   );

--- a/src/app/(auth-pages)/sign-up/form.tsx
+++ b/src/app/(auth-pages)/sign-up/form.tsx
@@ -2,7 +2,7 @@
 
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { redirect } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { useState } from "react";
 
@@ -17,6 +17,7 @@ import { signUpAction } from "@/server/auth/sign-up";
 export function SignUpForm() {
   const { toast } = useToast();
   const [pending, setPending] = useState(false);
+  const router = useRouter();
 
   const form = useForm<z.infer<typeof signUpFormSchema>>({
     resolver: zodResolver(signUpFormSchema),
@@ -37,14 +38,7 @@ export function SignUpForm() {
     actionResultMatch(
       result,
       () => {
-        toast({
-          title: "Verification Email Sent to " + values.email,
-          description: "Please check your email to verify your account.",
-          variant: "default",
-        });
-        setTimeout(() => {
-          redirect("/sign-in");
-        }, 3000);
+        router.push(`/confirmation-sent?email=${encodeURIComponent(values.email)}`);
       },
       (error) =>
         toast({

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -143,6 +143,7 @@ export const signUpUser = ({
               username,
               knumber,
               name,
+              siteUrl: origin, // Here, for preview and production deployments
             },
           },
         }),

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -25,6 +25,23 @@ export const exchangeCodeForSession = (code: string) =>
           } as ExchangeCodeError),
     );
 
+// Sends a confirmation email to the user after signing up, only if there is an inital sign up being done.
+// Otherwise, it does nothing, and doesn't return an error.
+export const resendConfirmationEmail = ({ email, redirectTo }: { email: string; redirectTo: string }) =>
+  createClient()
+    .andThen((supabase) =>
+      fromSafePromise(
+        supabase.auth.resend({
+          type: "signup",
+          email: email,
+          options: {
+            emailRedirectTo: redirectTo,
+          },
+        }),
+      ),
+    )
+    .andThen(() => okAsync());
+
 type VerifyOtpError = {
   message: string;
   code: "DATABASE_ERROR";

--- a/src/server/auth/sign-up.ts
+++ b/src/server/auth/sign-up.ts
@@ -7,11 +7,17 @@ import { okAsync } from "neverthrow";
 import { resultAsyncToActionResult } from "@/types/error-typing";
 import { signUpFormSchema } from "@/config/auth-schemas";
 import { parseSchema } from "@/utils/parse-schema";
-import { signUpUser } from "@/lib/auth";
+import { resendConfirmationEmail, signUpUser } from "@/lib/auth";
+import { getOrigin } from "@/lib/origin";
 
 export const signUpAction = async (values: z.infer<typeof signUpFormSchema>) =>
   resultAsyncToActionResult(
     parseSchema(signUpFormSchema, values)
       .asyncAndThen(() => signUpUser(values))
       .andThen(() => okAsync()),
+  );
+
+export const resendSignUpEmailConfirmationAction = async (email: string) =>
+  resultAsyncToActionResult(
+    getOrigin().andThen((origin) => resendConfirmationEmail({ email, redirectTo: `${origin}/my` })),
   );

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -107,7 +107,7 @@ enabled = true
 # in emails.
 site_url = "http://localhost:3000"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["http://localhost:3000/auth/confirm", "http://localhost:3000/**"]
+additional_redirect_urls = ["http://localhost:3000/confirm-email", "http://localhost:3000/**"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # If disabled, the refresh token will never expire.


### PR DESCRIPTION
Fix #36 by adding new pages on the pipeline (specifically, `/confirm-email` and `/confirmation-sent`)